### PR TITLE
Make retour act in a more natural way.

### DIFF
--- a/Ease.elm
+++ b/Ease.elm
@@ -332,4 +332,4 @@ retour easing time =
     else
         (time - 0.5)
             * 2
-            |> flip easing
+            |> reverse easing


### PR DESCRIPTION
Due to the definition of `flip`, the `retour` combinator worked strange. Consider the following:

    > List.map (Ease.retour Ease.linear << (\n -> n / 10)) [1,2,3,4,5,6,7,8,9,10]
    [0.2, 0.4, 0.6, 0.8, 0, 0.19999999999999996, 0.3999999999999999, 0.6000000000000001, 0.8, 1]

The expectation (based on reading the docs) is that it would go smoothly up, then back down. This is fixed by changing `flip` in the definition of `retour`to `reverse`, providing the following output:

    > List.map (Ease.retour Ease.linear << (\n -> n / 10)) [1,2,3,4,5,6,7,8,9,10]
    [0.2, 0.4, 0.6, 0.8, 1, 0.8, 0.6000000000000001, 0.3999999999999999, 0.19999999999999996, 0]