### PR TITLE
fix: reimplement bezier with correct behavior

### DIFF
--- a/src/Ease.elm
+++ b/src/Ease.elm
@@ -77,7 +77,7 @@ See [here](http://cubic-bezier.com/ "tester") to test.
 
 -}
 bezier : Float -> Float -> Float -> Float -> Easing
-bezier x1 y1 x2 y2 time =
+bezier x1 y1 x2 y2 =
     let
         f =
             bezierPoint x1 y1 x2 y2
@@ -86,13 +86,7 @@ bezier x1 y1 x2 y2 time =
             -- performance/quality tradeoff, 8 steps should be good enough in most cases
             8
     in
-    if time == 0 then
-        0
-
-    else if time == 1 then
-        1
-
-    else
+    \time ->
         bezierHelper numSteps f time ( 0, 1 )
 
 
@@ -108,7 +102,7 @@ bezierHelper steps f t ( tMin, tMax ) =
         ( x, y ) =
             f tMid
     in
-    if steps == 0 || x == t then
+    if steps == 0 then
         y
 
     else

--- a/test/Test.elm
+++ b/test/Test.elm
@@ -100,8 +100,8 @@ main : Svg a
 main =
     Svg.svg
         [ SvgAttributes.width "850"
-        , SvgAttributes.height "650"
-        , SvgAttributes.viewBox "-10 -60 840 590"
+        , SvgAttributes.height "760"
+        , SvgAttributes.viewBox "-10 -60 840 700"
         , SvgAttributes.style "display:block;margin:auto;"
         ]
         (title :: List.indexedMap plot easingFunctions)
@@ -138,4 +138,10 @@ easingFunctions =
     , ( inBounce, "inBounce" )
     , ( outBounce, "outBounce" )
     , ( inOutBounce, "inOutBounce" )
+    , ( bezier 1 0 0 1, "bezier 1" )
+    , ( bezier 1 0 0 0, "bezier 2" )
+    , ( bezier 0 0 0 1, "bezier 3" )
+    , ( bezier 0 1 1 0, "bezier 4" )
+    , ( bezier 1 1 1 0, "bezier 5" )
+    , ( bezier 1 1 0 1, "bezier 6" )
     ]

--- a/test/elm.json
+++ b/test/elm.json
@@ -4,7 +4,7 @@
         ".",
         "../src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/core": "1.0.0",


### PR DESCRIPTION
Following the discussion in #4, this PR fixes the `bezier` function so that it behaves correctly.
The problem was the invalid assumption that the `x` coordinate of the calculated point is equal to the `time` parameter in the equation. The new implementation performs a binary search to find a point whose `x` coordinate is closer to the `time` parameter.

The original point-calculating function was replaced with a simpler one, and turned out to be much more performant (even after some optimizations).

I came up with a few binary search implementations, but they all perform kinda the same. I also asked @MartinSStewart if he still had his binary search implementation - he had it, but for some reason it was much slower than others, so it was abandoned.

[Here are the benchmarks](https://megapctr.github.io/elm-cubic-bezier/). This PR uses`bezierBinFixed` and `bezierPointSimple` implementations.
The repo with the benchmarks can be found [here](https://github.com/megapctr/elm-cubic-bezier).

Should the benchmarks be included in this repo?